### PR TITLE
Update app using `React.render`

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -8,14 +8,11 @@ class AppComponent extends React.Component {
 
         super(props);
 
-        /*
         this.state = {
             robotLoaded: false
         };
 
-        this.onRobotLoaded.bind(this);
-        */
-
+        this.onRobotLoaded = this.onRobotLoaded.bind(this);
     }
 
     render() {
@@ -39,7 +36,7 @@ class AppComponent extends React.Component {
         let RobotElement = React.createElement(
             RobotComponent,
             {
-                onLoad: this.onRobotLoaded.bind(this),
+                onLoad: this.onRobotLoaded,
                 position: this.props.robotPosition || new THREE.Vector3(0,0,0)
             }
         );
@@ -58,12 +55,9 @@ class AppComponent extends React.Component {
         )
     }
 
-    /*
     onRobotLoaded() {
         this.setState({robotLoaded: true});
     }
-    */
-
 }
 
 AppComponent.propTypes = {

--- a/src/main.js
+++ b/src/main.js
@@ -3,15 +3,16 @@ import AppComponent from './components/app';
 
 let tempY = 0;
 
-let app = React.render(
-    React.createElement( AppComponent, {history: true} ),
-    document.getElementById('app')
-);
+let appState = { history: true, robotPosition: new THREE.Vector3(0,0,0) }
 
 function animate() {
     tempY++;
-    app.props.robotPosition = new THREE.Vector3(0, tempY, 0);
-    app.render();
+    appState.robotPosition.y = tempY;
+    React.render(
+        React.createElement( AppComponent, appState ),
+        document.getElementById('app')
+    );
+  
     requestAnimationFrame(animate);
 }
 


### PR DESCRIPTION
This updates the app to submit changes by repeatedly calling `React.render()` with a new element created from the updated props (which I'm calling `appstate`). As far as I know this is the generally suggested method of updating your view going forward. This gets you as far as having a moving black cube.

Regarding the texture not appearing: I tried pointing the texture loader at `./models/cupCake.png` but that didn't work. If I had to guess I think it's due to the use of `browserify-shim` to provide a copy of three.js. It may be that your code is referring to the global three.js (the one loaded from bower_components) while react-three is using its own copy of three.js loaded from node_modules. So basically you have two instances of three.js loaded! So it may be you're loading the texture using one instance of three.js and then trying to use it in the other instance.

This is all speculation of course, I haven't used `browserify-shim` too much so it may be doing the right thing. Plus you probably need the shim for the Collada loader. But you might want to try taking the shim out and then check if the box is properly textured.
